### PR TITLE
Attempt to make the unsubscribe event work

### DIFF
--- a/src/Controller/SubscriptionNormalizerTrait.php
+++ b/src/Controller/SubscriptionNormalizerTrait.php
@@ -15,7 +15,7 @@ trait SubscriptionNormalizerTrait
             'type' => 'Subscription',
             'subscriber' => $subscriber->id,
             'topic' => $topic,
-            'active' => true,
+            'active' => $active,
             'payload' => $subscriber->payload
         ];
     }


### PR DESCRIPTION
To test this, run the following:

1. `bin/main.php`
2. Listen to active subscriptions (using `Listen subscriptions` button)
3. Subscribe (using `Subscribe` button)
4. Unsubscribe
5. The subscription should have appear and disappear

Notice: by default, the tool is using HTTP Header implementation that is not supported in the network tab of the browser, so you may want to change to "cookie authentication" before any kind of test.
![image](https://user-images.githubusercontent.com/972456/215581936-b29aa83e-b350-4003-9e51-f12ba11b6008.png)
